### PR TITLE
Discord invite command

### DIFF
--- a/DiscordLink/DiscordLink.cs
+++ b/DiscordLink/DiscordLink.cs
@@ -527,7 +527,6 @@ namespace Eco.Plugins.DiscordLink
             _chatLogWriter = null;
             _chatlogInitialized = false;
         }
-        }
         #endregion
     }
 

--- a/DiscordLink/DiscordLink.cs
+++ b/DiscordLink/DiscordLink.cs
@@ -26,7 +26,7 @@ namespace Eco.Plugins.DiscordLink
     public class DiscordLink : IModKitPlugin, IInitializablePlugin, IConfigurablePlugin
     {
         protected string NametagColor = "7289DAFF";
-        private PluginConfig<DiscordConfig> configOptions;
+        private PluginConfig<DiscordConfig> _configOptions;
         private DiscordClient _discordClient;
         private CommandsNextModule _commands;
         private string _currentToken;
@@ -46,7 +46,7 @@ namespace Eco.Plugins.DiscordLink
 
         public IPluginConfig PluginConfig
         {
-            get { return configOptions; }
+            get { return _configOptions; }
         }
 
         public DiscordConfig DiscordPluginConfig
@@ -80,7 +80,7 @@ namespace Eco.Plugins.DiscordLink
             SetupConfig();
             chatNotifier = new ChatNotifier(new IChatMessageProviderChatServerWrapper());
             SetUpClient();
-            if(configOptions.Config.LogChat)
+            if(_configOptions.Config.LogChat)
             {
                 StartChatlog();
             }
@@ -88,7 +88,7 @@ namespace Eco.Plugins.DiscordLink
 
         ~DiscordLink()
         {
-            if (configOptions.Config.LogChat)
+            if (_configOptions.Config.LogChat)
             {
                 StopChatlog();
             }
@@ -96,7 +96,7 @@ namespace Eco.Plugins.DiscordLink
 
         private void SetupConfig()
         {
-            configOptions = new PluginConfig<DiscordConfig>("DiscordPluginSpoffy");
+            _configOptions = new PluginConfig<DiscordConfig>("DiscordPluginSpoffy");
             DiscordPluginConfig.ChannelLinks.CollectionChanged += (obj, args) => { SaveConfig(); };
         }
 
@@ -428,7 +428,7 @@ namespace Eco.Plugins.DiscordLink
 
         public object GetEditObject()
         {
-            return configOptions.Config;
+            return _configOptions.Config;
         }
 
         public void OnEditObjectChanged(object o, string param)
@@ -439,7 +439,7 @@ namespace Eco.Plugins.DiscordLink
         protected void SaveConfig()
         {
             Logger.DebugVerbose("Saving Config");
-            configOptions.Save();
+            _configOptions.Save();
             if (DiscordPluginConfig.BotToken != _currentToken)
             {
                 //Reinitialise client.
@@ -477,7 +477,7 @@ namespace Eco.Plugins.DiscordLink
 
         public void SavePlayerConfig()
         {
-            configOptions.Save();
+            _configOptions.Save();
         }
 
         public DiscordChannel GetDefaultChannelForPlayer(string identifier)
@@ -511,13 +511,13 @@ namespace Eco.Plugins.DiscordLink
         {
             try
             {
-                _chatLogWriter = new StreamWriter(configOptions.Config.ChatlogPath, append: true);
+                _chatLogWriter = new StreamWriter(_configOptions.Config.ChatlogPath, append: true);
                 _chatLogWriter.AutoFlush = true;
                 _chatlogInitialized = true;
             }
             catch(Exception)
             {
-                Logger.Error("Failed to initialize chat logger using path \"" + configOptions.Config.ChatlogPath + "\"");
+                Logger.Error("Failed to initialize chat logger using path \"" + _configOptions.Config.ChatlogPath + "\"");
             }
         }
 

--- a/DiscordLink/DiscordLink.cs
+++ b/DiscordLink/DiscordLink.cs
@@ -26,6 +26,8 @@ namespace Eco.Plugins.DiscordLink
 {
     public class DiscordLink : IModKitPlugin, IInitializablePlugin, IConfigurablePlugin
     {
+        public const string InviteCommandLinkToken = "[LINK]";
+        public const string DiscordCommandPrefix = "?";
         protected string NametagColor = "7289DAFF";
         private PluginConfig<DiscordConfig> _configOptions;
         private DiscordConfig _prevConfigOptions; // Used to detect differances when the config is saved
@@ -35,7 +37,6 @@ namespace Eco.Plugins.DiscordLink
         private string _status = "No Connection Attempt Made";
         private StreamWriter _chatLogWriter;
 
-        private const string CommandPrefix = "?";
 
         private static readonly Regex TagStripRegex = new Regex("<[^>]*>");
 
@@ -147,7 +148,7 @@ namespace Eco.Plugins.DiscordLink
                 // Set up the client to use CommandsNext
                 _commands = _discordClient.UseCommandsNext(new CommandsNextConfiguration
                 {
-                    StringPrefix = CommandPrefix
+                    StringPrefix = DiscordCommandPrefix
                 });
 
                 _commands.RegisterCommands<DiscordDiscordCommands>();
@@ -272,10 +273,10 @@ namespace Eco.Plugins.DiscordLink
         private string EcoUserSteamId = "DiscordLinkSteam";
         private string EcoUserSlgId = "DiscordLinkSlg";
         private string EcoUserName = "Discord";
-        private User _ecoUser;
         private bool _relayInitialised = false;
 
-        protected User EcoUser =>
+        private User _ecoUser;
+        public User EcoUser =>
             _ecoUser ?? (_ecoUser = UserManager.GetOrCreateUser(EcoUserSteamId, EcoUserSlgId, EcoUserName));
 
         private void BeginRelaying()
@@ -360,7 +361,7 @@ namespace Eco.Plugins.DiscordLink
         {
             LogDiscordMessage(message);
             if (message.Author == _discordClient.CurrentUser) { return; }
-            if (message.Content.StartsWith(CommandPrefix)) { return; }
+            if (message.Content.StartsWith(DiscordCommandPrefix)) { return; }
             
             var channelLink = GetLinkForEcoChannel(message.Channel.Name) ?? GetLinkForEcoChannel(message.Channel.Id.ToString());
             var channel = channelLink?.EcoChannel;
@@ -476,6 +477,16 @@ namespace Eco.Plugins.DiscordLink
                 RestartChatlog();
             }
 
+            if(string.IsNullOrEmpty(_configOptions.Config.EcoCommandChannel))
+            {
+                _configOptions.Config.EcoCommandChannel = DiscordConfig.DefaultValues.EcoCommandChannel;
+            }
+
+            if (string.IsNullOrEmpty(_configOptions.Config.InviteMessage))
+            {
+                _configOptions.Config.InviteMessage = DiscordConfig.DefaultValues.InviteMessage;
+            }
+
             _prevConfigOptions = (DiscordConfig)_configOptions.Config.Clone();
         }
 
@@ -536,6 +547,18 @@ namespace Eco.Plugins.DiscordLink
                 errorMessages.Add("[Verification] No Discord Client available.");
             }
 
+            // Eco command channel
+            if (_configOptions.Config.EcoCommandChannel.Contains('#'))
+            {
+                errorMessages.Add("[Eco Command Channel] Channel name contains a channel indicator (#). The channel indicator will be added automatically and adding one manually may cause message sending to fail");
+            }
+
+            if (!_configOptions.Config.InviteMessage.Contains(InviteCommandLinkToken))
+            {
+                errorMessages.Add("[Invite Message] Message does not contain the invite link token " + InviteCommandLinkToken + ". If the invite link has been added manually, consider adding it to the network config instead");
+            }
+
+            // Report errors
             if (errorMessages.Count <= 0)
             {
                 Logger.Info("Configuration verification completed without errors");
@@ -641,6 +664,12 @@ namespace Eco.Plugins.DiscordLink
 
     public class DiscordConfig : ICloneable
     {
+        public static class DefaultValues
+        {
+            public const string EcoCommandChannel = "General";
+            public const string InviteMessage = "Join us on Discord!\n" + DiscordLink.InviteCommandLinkToken;
+        }
+
         public object Clone() // Be careful not to change the original object here as that will trigger endless recursion.
         {
             return new DiscordConfig
@@ -699,6 +728,12 @@ namespace Eco.Plugins.DiscordLink
 
         [Description("The path to the chatlog file, including file name and extension. This setting can be changed while the server is running, but the existing chatlog will not transfer."), Category("Chatlog Configuration")]
         public string ChatlogPath { get; set; } = Directory.GetCurrentDirectory() + "\\Logs\\DiscordLinkChatlog.txt";
+
+        [Description("The Eco chat channel to use for commands that outputs public messages, excluding the initial # character. This setting can be changed while the server is running."), Category("Command Settings")]
+        public string EcoCommandChannel { get; set; } = DefaultValues.EcoCommandChannel;
+
+        [Description("The message to use for the /DiscordInvite command. The invite link is fetched from the network config and will replace the token " + DiscordLink.InviteCommandLinkToken + ". This setting can be changed while the server is running."), Category("Command Settings")]
+        public string InviteMessage { get; set; } = DefaultValues.InviteMessage;
     }
 
     public class DiscordPlayerConfig : ICloneable

--- a/DiscordLink/DiscordLink.cs
+++ b/DiscordLink/DiscordLink.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -81,7 +82,8 @@ namespace Eco.Plugins.DiscordLink
             SetupConfig();
             chatNotifier = new ChatNotifier(new IChatMessageProviderChatServerWrapper());
             SetUpClient();
-            if(_configOptions.Config.LogChat)
+            VerifyConfig(); // Requires SetUpClient to run first so that the DiscordClient exists
+            if (_configOptions.Config.LogChat)
             {
                 StartChatlog();
             }
@@ -99,7 +101,8 @@ namespace Eco.Plugins.DiscordLink
         {
             _configOptions = new PluginConfig<DiscordConfig>("DiscordPluginSpoffy");
             _prevConfigOptions = (DiscordConfig)_configOptions.Config.Clone();
-            DiscordPluginConfig.ChannelLinks.CollectionChanged += (obj, args) => { SaveConfig(); };
+            DiscordPluginConfig.PlayerConfigs.CollectionChanged += (obj, args) => { OnConfigChanged(); };
+            DiscordPluginConfig.ChannelLinks.CollectionChanged += (obj, args) => { OnConfigChanged(); };
         }
 
         #region DiscordClient Management
@@ -435,7 +438,13 @@ namespace Eco.Plugins.DiscordLink
 
         public void OnEditObjectChanged(object o, string param)
         {
+            OnConfigChanged();
+        }
+
+        public void OnConfigChanged()
+        {
             SaveConfig();
+            VerifyConfig();
         }
 
         protected void SaveConfig()
@@ -468,6 +477,78 @@ namespace Eco.Plugins.DiscordLink
             }
 
             _prevConfigOptions = (DiscordConfig)_configOptions.Config.Clone();
+        }
+
+        private void VerifyConfig()
+        {
+            List<string> errorMessages = new List<string>();
+
+            // Server IP
+            if (!string.IsNullOrWhiteSpace(_configOptions.Config.ServerIP))
+            {
+                IPAddress address;
+                if (!IPAddress.TryParse(_configOptions.Config.ServerIP, out address)
+                    || (address.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork
+                    && address.AddressFamily != System.Net.Sockets.AddressFamily.InterNetworkV6))
+                {
+                    errorMessages.Add("[ServerIP] Not a valid IPv4 or IPv6 address");
+                }
+            }
+
+            // Player configs
+            foreach (DiscordPlayerConfig playerConfig in _configOptions.Config.PlayerConfigs)
+            {
+                bool found = false;
+                foreach(User user in UserManager.Users)
+                {
+                    if (user.Name == playerConfig.Username)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                if(!found)
+                {
+                    errorMessages.Add("[Player Configs] No user with name \"" + playerConfig.Username + "\" was found");
+                }
+            }
+
+            // Channel links
+            if (_discordClient != null)
+            {
+                foreach (ChannelLink link in _configOptions.Config.ChannelLinks)
+                {
+                    var guild = GuildByNameOrId(link.DiscordGuild);
+                    if(guild == null)
+                    {
+                        errorMessages.Add("[Channel Links] No Discord Guild with the name \"" + link.DiscordGuild + "\" could be found");
+                        continue; // The channel will always fail if the guild fails
+                    }
+                    var channel = guild.ChannelByNameOrId(link.DiscordChannel);
+                    if (channel == null)
+                    {
+                        errorMessages.Add("[Channel Links] No Channel with the name \"" + link.DiscordGuild + "\" could be found in the Guild \"" + link.DiscordGuild + "\"" );
+                    }
+                }
+            }
+            else
+            {
+                errorMessages.Add("[Verification] No Discord Client available.");
+            }
+
+            if (errorMessages.Count <= 0)
+            {
+                Logger.Info("Configuration verification completed without errors");
+            }
+            else
+            {
+                string concatenatedMessages = "";
+                foreach (string message in errorMessages)
+                {
+                    concatenatedMessages += message + "\n";
+                }
+                Logger.Error("Configuration errors detected!\n" + concatenatedMessages);
+            }
         }
 
         #endregion
@@ -572,7 +653,7 @@ namespace Eco.Plugins.DiscordLink
                 Debug = this.Debug,
                 LogChat = this.LogChat,
                 ChatlogPath = this.ChatlogPath,
-                PlayerConfigs = this.PlayerConfigs.Select(t => t.Clone()).Cast<DiscordPlayerConfig>().ToList(),
+                PlayerConfigs = new ObservableCollection<DiscordPlayerConfig>(this.PlayerConfigs.Select(t => t.Clone()).Cast<DiscordPlayerConfig>()),
                 ChannelLinks = new ObservableCollection<ChannelLink>(this.ChannelLinks.Select(t => t.Clone()).Cast<ChannelLink>())
             };
         }
@@ -592,10 +673,10 @@ namespace Eco.Plugins.DiscordLink
         [Description("IP of the server. Overrides the automatically detected IP. This setting can be changed while the server is running."), Category("Server Details")]
         public string ServerIP { get; set; }
 
-        private List<DiscordPlayerConfig> _playerConfigs = new List<DiscordPlayerConfig>();
+        private ObservableCollection<DiscordPlayerConfig> _playerConfigs = new ObservableCollection<DiscordPlayerConfig>();
 
         [Description("A mapping from user to user config parameters. This setting can be changed while the server is running.")]
-        public List<DiscordPlayerConfig> PlayerConfigs
+        public ObservableCollection<DiscordPlayerConfig> PlayerConfigs
         {
             get
             {

--- a/DiscordLink/DiscordLink.cs
+++ b/DiscordLink/DiscordLink.cs
@@ -27,6 +27,7 @@ namespace Eco.Plugins.DiscordLink
     {
         protected string NametagColor = "7289DAFF";
         private PluginConfig<DiscordConfig> _configOptions;
+        private DiscordConfig _prevConfigOptions; // Used to detect differances when the config is saved
         private DiscordClient _discordClient;
         private CommandsNextModule _commands;
         private string _currentToken;
@@ -97,6 +98,7 @@ namespace Eco.Plugins.DiscordLink
         private void SetupConfig()
         {
             _configOptions = new PluginConfig<DiscordConfig>("DiscordPluginSpoffy");
+            _prevConfigOptions = (DiscordConfig)_configOptions.Config.Clone();
             DiscordPluginConfig.ChannelLinks.CollectionChanged += (obj, args) => { SaveConfig(); };
         }
 
@@ -440,12 +442,32 @@ namespace Eco.Plugins.DiscordLink
         {
             Logger.DebugVerbose("Saving Config");
             _configOptions.Save();
+
             if (DiscordPluginConfig.BotToken != _currentToken)
             {
                 //Reinitialise client.
                 Logger.Info("Discord Token changed, reinitialising client.\n");
                 RestartClient();
             }
+
+            if(_configOptions.Config.LogChat && !_prevConfigOptions.LogChat)
+            {
+                Logger.Info("Chatlog enabled");
+                StartChatlog();
+            }
+            else if(!_configOptions.Config.LogChat && _prevConfigOptions.LogChat)
+            {
+                Logger.Info("Chatlog disabled");
+                StopChatlog();
+            }
+
+            if( _configOptions.Config.ChatlogPath != _prevConfigOptions.ChatlogPath)
+            {
+                Logger.Info("Chatlog path changed. New path: " + _configOptions.Config.ChatlogPath);
+                RestartChatlog();
+            }
+
+            _prevConfigOptions = (DiscordConfig)_configOptions.Config.Clone();
         }
 
         #endregion
@@ -527,29 +549,52 @@ namespace Eco.Plugins.DiscordLink
             _chatLogWriter = null;
             _chatlogInitialized = false;
         }
+
+        private void RestartChatlog()
+        {
+            StopChatlog();
+            StartChatlog();
+        }
         #endregion
     }
 
-    public class DiscordConfig
+    public class DiscordConfig : ICloneable
     {
-        [Description("The token provided by the Discord API to allow access to the bot"), Category("Bot Configuration")]
+        public object Clone() // Be careful not to change the original object here as that will trigger endless recursion.
+        {
+            return new DiscordConfig
+            {
+                BotToken = this.BotToken,
+                ServerName = this.ServerName,
+                ServerDescription = this.ServerDescription,
+                ServerLogo = this.ServerLogo,
+                ServerIP = this.ServerIP,
+                Debug = this.Debug,
+                LogChat = this.LogChat,
+                ChatlogPath = this.ChatlogPath,
+                PlayerConfigs = this.PlayerConfigs.Select(t => t.Clone()).Cast<DiscordPlayerConfig>().ToList(),
+                ChannelLinks = new ObservableCollection<ChannelLink>(this.ChannelLinks.Select(t => t.Clone()).Cast<ChannelLink>())
+            };
+        }
+
+        [Description("The token provided by the Discord API to allow access to the bot. This setting can be changed while the server is running and will in that case trigger a reconnection to Discord."), Category("Bot Configuration")]
         public string BotToken { get; set; }
 
-        [Description("The name of the Eco server, overriding the name configured within Eco."), Category("Server Details")]
+        [Description("The name of the Eco server, overriding the name configured within Eco. This setting can be changed while the server is running."), Category("Server Details")]
         public string ServerName { get; set; }
 
-        [Description("The description of the Eco server, overriding the description configured within Eco."), Category("Server Details")]
+        [Description("The description of the Eco server, overriding the description configured within Eco. This setting can be changed while the server is running."), Category("Server Details")]
         public string ServerDescription { get; set; }
 
-        [Description("The logo of the server as a URL."), Category("Server Details")]
+        [Description("The logo of the server as a URL. This setting can be changed while the server is running."), Category("Server Details")]
         public string ServerLogo { get; set; }
 
-        [Description("IP of the server. Overrides the automatically detected IP."), Category("Server Details")]
+        [Description("IP of the server. Overrides the automatically detected IP. This setting can be changed while the server is running."), Category("Server Details")]
         public string ServerIP { get; set; }
 
         private List<DiscordPlayerConfig> _playerConfigs = new List<DiscordPlayerConfig>();
 
-        [Description("A mapping from user to user config parameters.")]
+        [Description("A mapping from user to user config parameters. This setting can be changed while the server is running.")]
         public List<DiscordPlayerConfig> PlayerConfigs
         {
             get
@@ -562,21 +607,26 @@ namespace Eco.Plugins.DiscordLink
             }
         }
 
-        [Description("Channels to connect together."), Category("Channel Configuration")]
+        [Description("Channels to connect together. This setting can be changed while the server is running."), Category("Channel Configuration")]
         public ObservableCollection<ChannelLink> ChannelLinks { get; set; } = new ObservableCollection<ChannelLink>();
 
-        [Description("Enables debugging output to the console."), Category("Debugging")]
+        [Description("Enables debugging output to the console. This setting can be changed while the server is running."), Category("Debugging")]
         public bool Debug { get; set; } = false;
 
-        [Description("Enables logging of chat messages into the file at ChatlogPath."), Category("Chatlog Configuration")]
+        [Description("Enables logging of chat messages into the file at Chatlog Path. This setting can be changed while the server is running."), Category("Chatlog Configuration")]
         public bool LogChat { get; set; } = false;
 
-        [Description("The path to the chatlog file, including file name and extension."), Category("Chatlog Configuration")]
+        [Description("The path to the chatlog file, including file name and extension. This setting can be changed while the server is running, but the existing chatlog will not transfer."), Category("Chatlog Configuration")]
         public string ChatlogPath { get; set; } = Directory.GetCurrentDirectory() + "\\Logs\\DiscordLinkChatlog.txt";
     }
 
-    public class DiscordPlayerConfig
+    public class DiscordPlayerConfig : ICloneable
     {
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+
         [Description("ID of the user")]
         public string Username { get; set; }
 
@@ -594,8 +644,13 @@ namespace Eco.Plugins.DiscordLink
         }
     }
 
-    public class ChannelLink
+    public class ChannelLink : ICloneable
     {
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+
         [Description("Discord Guild channel is in by name or ID. Case sensitive.")]
         public string DiscordGuild { get; set; }
 


### PR DESCRIPTION
Added DiscordInvite command added to both Discord and Eco.
It outputs a configurable message into the Eco chat with an invite link to the Discord server configured in the Network config.

PR Dependencies: https://github.com/Spoffy/EcoDiscordPlugin/pull/36 (Merge conflicts should be resolved after this dependency is merged).